### PR TITLE
fix: keep entry file hash stable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ config
 temp
 .nyc_output
 coverage.lcov
+/package-lock.json

--- a/lib/base.js
+++ b/lib/base.js
@@ -607,7 +607,7 @@ class WebpackBaseBuilder {
 
   createFileName() {
     if (this.config.fileHash) {
-      this.config.filename = Utils.assetsPath(this.config.prefix, `js/[name].[hash:${this.config.hashLength}].js`);
+      this.config.filename = Utils.assetsPath(this.config.prefix, `js/[name].[chunkhash:${this.config.hashLength}].js`);
       this.config.chunkFilename = Utils.assetsPath(this.config.prefix, `js/chunk/[name].[chunkhash:${this.config.hashLength}].js`);
     } else {
       this.config.filename = Utils.assetsPath(this.config.prefix, 'js/[name].js');

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -157,7 +157,7 @@ describe('client.test.js', () => {
       const webpackConfig = builder.create();
       builder.webpackConfig = webpackConfig;
       expect(webpackConfig.output.publicPath).to.equal('/public/');
-      expect(webpackConfig.output.filename).to.include('js/[name].[hash:8].js');
+      expect(webpackConfig.output.filename).to.include('js/[name].[chunkhash:8].js');
       expect(webpackConfig.output.chunkFilename).to.include('js/chunk/[name].[chunkhash:8].js');
       expect(builder.hasPlugin('ImageminPlugin')).to.be.true;
       expect(builder.hasPlugin('UglifyJsPlugin')).to.be.true;


### PR DESCRIPTION
用 [hash] 每次构建生成的 hash 都会变，这样每次构建后浏览器缓存都会失效。换成 [chunkhash] 会让 entry file 的 hash 不会因为随着每次构建而改变，虽然还有些其他问题，https://github.com/webpack/webpack/issues/1315

另外，是否考虑让这些内部写死的选项也可以用 webpack.config.js 来配置